### PR TITLE
Add button to download tournament bracket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "chart.js": "^4.4.0",
         "chartjs-adapter-date-fns": "^3.0.0",
         "date-fns": "^3.3.1",
+        "html-to-image": "^1.11.11",
         "mobile-drag-drop": "^3.0.0-rc.0",
         "nanoid": "^5.0.1",
         "pinia": "^2.1.6",
@@ -1507,6 +1508,11 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chart.js": "^4.4.0",
     "chartjs-adapter-date-fns": "^3.0.0",
     "date-fns": "^3.3.1",
+    "html-to-image": "^1.11.11",
     "mobile-drag-drop": "^3.0.0-rc.0",
     "nanoid": "^5.0.1",
     "pinia": "^2.1.6",


### PR DESCRIPTION
The PR adds a button on the tournament view that allows users to download the bracket (creates a PNG) when the tournament has concluded.

It uses `html-to-image` to convert DOM elements to PNG.